### PR TITLE
Grid and Scheduler DnD demo prevent event attaching on every render

### DIFF
--- a/knowledge-base/examples/scheduler/dnd-from-grid/main.jsx
+++ b/knowledge-base/examples/scheduler/dnd-from-grid/main.jsx
@@ -1,53 +1,61 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom';
 import {
   Scheduler,
   WeekView,
   MonthView,
-} from "@progress/kendo-react-scheduler";
+} from '@progress/kendo-react-scheduler';
 
-import { Grid, GridColumn } from "@progress/kendo-react-grid";
+import { Grid, GridColumn } from '@progress/kendo-react-grid';
 
-import gridData from "./data.js";
+import gridData from './data.js';
 
 const handleDragOver = (e) => {
   e.preventDefault();
 };
 
 const App = () => {
-  const MyScheduler = React.createRef();
+  const MyScheduler = React.useRef();
+  const refData = React.useRef();
+  const refDragItem = React.useRef();
   const [data, setData] = React.useState([]);
-  const [dragItem, setDragItem] = React.useState("");
-  const handleDropItem = (e) => {
-    let start = e.target.getAttribute("data-slot-start");
-    let end = e.target.getAttribute("data-slot-end");
+
+  refData.current = data;
+  refDragItem.current = null;
+
+  const handleDropItem = React.useCallback((e) => {
+    let start = e.target.getAttribute('data-slot-start');
+    let end = e.target.getAttribute('data-slot-end');
     let startDate = new Date(parseInt(start));
     let endDate = new Date(parseInt(end));
+
     let newEvent = {
-      id: dragItem.taskID,
-      title: dragItem.title,
+      id: refDragItem.current.taskID,
+      title: refDragItem.current.title,
       StartTimezone: null,
       start: startDate,
       end: endDate,
     };
-    setData([newEvent, ...data]);
-  };
+    const newData = [newEvent, ...refData.current];
+    refData.current = newData;
+    setData(newData);
+  }, []);
 
   React.useEffect(() => {
     let schedulerElement = MyScheduler.current.element;
-    schedulerElement.addEventListener("drop", handleDropItem);
-    schedulerElement.addEventListener("dragover", handleDragOver);
+    schedulerElement.addEventListener('drop', handleDropItem);
+    schedulerElement.addEventListener('dragover', handleDragOver);
     return () => {
-      schedulerElement.removeEventListener("drop", handleDropItem);
-      schedulerElement.removeEventListener("dragover", handleDragOver);
+      schedulerElement.removeEventListener('drop', handleDropItem);
+      schedulerElement.removeEventListener('dragover', handleDragOver);
     };
-  });
+  }, []);
 
   const GridRowRender = (tr, props) => {
     const trProps = {
       draggable: true,
-      onDragStart: (e) => {
-        setDragItem(props.dataItem);
+      onDragStart: () => {
+        refDragItem.current = props.dataItem;
       },
     };
     return React.cloneElement(tr, { ...trProps }, tr.props.children);
@@ -56,7 +64,7 @@ const App = () => {
     <>
       <Scheduler
         data={data}
-        defaultDate={new Date("2013/6/13")}
+        defaultDate={new Date('2013/6/13')}
         ref={MyScheduler}
       >
         <WeekView showWorkHours={false} />
@@ -71,4 +79,4 @@ const App = () => {
   );
 };
 
-ReactDOM.render(<App />, document.querySelector("my-app"));
+ReactDOM.render(<App />, document.querySelector('my-app'));

--- a/knowledge-base/examples/scheduler/dnd-from-grid/main.jsx
+++ b/knowledge-base/examples/scheduler/dnd-from-grid/main.jsx
@@ -1,62 +1,74 @@
 import * as React from "react";
 import * as ReactDOM from "react-dom";
 import {
-    Scheduler,
-    WeekView,
-    MonthView
+  Scheduler,
+  WeekView,
+  MonthView,
 } from "@progress/kendo-react-scheduler";
 
 import { Grid, GridColumn } from "@progress/kendo-react-grid";
 
 import gridData from "./data.js";
 
-const App = () => {
-    const MyScheduler = React.createRef();
-    const [data, setData] = React.useState([]);
-    const [dragTitle, setDragTitle] = React.useState("");
-    const [dragItem, setDragItem] = React.useState("");
-    const handleDropItem = e => {
-        let start = e.target.getAttribute("data-slot-start");
-        let end = e.target.getAttribute("data-slot-end");
-        let startDate = new Date(parseInt(start));
-        let endDate = new Date(parseInt(end));
-        let newEvent = {
-            id: dragItem.taskID,
-            title: dragItem.title,
-            StartTimezone: null,
-            start: startDate,
-            end: endDate
-        };
-        setData([newEvent, ...data]);
-    };
-    React.useEffect(() => {
-        let schedulerElement = MyScheduler.current.element;
-        schedulerElement.addEventListener("drop", handleDropItem);
-        schedulerElement.addEventListener("dragover", e => e.preventDefault());
-    });
+const handleDragOver = (e) => {
+  e.preventDefault();
+};
 
-    const GridRowRender = (tr, props) => {
-        const trProps = {
-            draggable: true,
-            onDragStart: e => {
-                setDragItem(props.dataItem)
-            }
-        };
-        return React.cloneElement(tr, { ...trProps }, tr.props.children);
+const App = () => {
+  const MyScheduler = React.createRef();
+  const [data, setData] = React.useState([]);
+  const [dragItem, setDragItem] = React.useState("");
+  const handleDropItem = (e) => {
+    let start = e.target.getAttribute("data-slot-start");
+    let end = e.target.getAttribute("data-slot-end");
+    let startDate = new Date(parseInt(start));
+    let endDate = new Date(parseInt(end));
+    let newEvent = {
+      id: dragItem.taskID,
+      title: dragItem.title,
+      StartTimezone: null,
+      start: startDate,
+      end: endDate,
     };
-    return (
-        <>
-            <Scheduler data={data} defaultDate={new Date("2013/6/13")} ref={MyScheduler}>
-                <WeekView showWorkHours={false} />
-                <MonthView />
-            </Scheduler>
-            <hr />
-            <Grid data={gridData} rowRender={GridRowRender}>
-                <GridColumn field='taskID' />
-                <GridColumn field='title' />
-            </Grid>
-        </>
-    );
+    setData([newEvent, ...data]);
+  };
+
+  React.useEffect(() => {
+    let schedulerElement = MyScheduler.current.element;
+    schedulerElement.addEventListener("drop", handleDropItem);
+    schedulerElement.addEventListener("dragover", handleDragOver);
+    return () => {
+      schedulerElement.removeEventListener("drop", handleDropItem);
+      schedulerElement.removeEventListener("dragover", handleDragOver);
+    };
+  });
+
+  const GridRowRender = (tr, props) => {
+    const trProps = {
+      draggable: true,
+      onDragStart: (e) => {
+        setDragItem(props.dataItem);
+      },
+    };
+    return React.cloneElement(tr, { ...trProps }, tr.props.children);
+  };
+  return (
+    <>
+      <Scheduler
+        data={data}
+        defaultDate={new Date("2013/6/13")}
+        ref={MyScheduler}
+      >
+        <WeekView showWorkHours={false} />
+        <MonthView />
+      </Scheduler>
+      <hr />
+      <Grid data={gridData} rowRender={GridRowRender}>
+        <GridColumn field="taskID" />
+        <GridColumn field="title" />
+      </Grid>
+    </>
+  );
 };
 
 ReactDOM.render(<App />, document.querySelector("my-app"));


### PR DESCRIPTION
In the below KB article, the drop event is fired multiple times:

- [Drag and Drop Items From the KendoReact Grid to the KendoReact Scheduler - KendoReact Grid KendoReact Scheduler (telerik.com)](https://www.telerik.com/kendo-react-ui/components/knowledge-base/grid-scheduler-drag-and-drop/)

Related to https://github.com/telerik/kendo-react-private/issues/3170